### PR TITLE
Revert gas prompt and bump to version 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5
+
+* Revert the "Max Gas" calculation
+
 ## 0.2.4
 
 * Minor changes to the prompts of MAKE_TRANSFER_TX APDU.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.5
 
-* Revert the "Max Gas" calculation
+* Revert the "Max Gas" calculation.
+* Minor changes to Gas prompts of MAKE_TRANSFER_TX APDU.
 
 ## 0.2.4
 

--- a/rust-app/Cargo.lock
+++ b/rust-app/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "kadena"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "arrayvec",
  "base64",

--- a/rust-app/Cargo.toml
+++ b/rust-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kadena"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["jonored", "yhql"]
 edition = "2018"
 autobins = false

--- a/rust-app/src/implementation.rs
+++ b/rust-app/src/implementation.rs
@@ -889,12 +889,13 @@ fn handle_tx_params_2(
     // The JSON struct ends here
     write!(hasher, "}}").ok()?;
 
-    use core::str::FromStr;
-    let gas_limit_f64: f64 = f64::from_str(gas_limit_str).ok()?;
-    let gas_price_f64: f64 = f64::from_str(gas_price_str).ok()?;
-    scroller("Max Gas", |w| {
-        Ok(write!(w, "KDA {}", gas_limit_f64 * gas_price_f64)?)
-    })
+    scroller("Paying Gas (1/2)", |w| {
+        Ok(write!(w, "At most {}", from_utf8(gas_limit)?,)?)
+    })?;
+    scroller("Paying Gas (2/2)", |w| {
+        Ok(write!(w, "Price {}", from_utf8(gas_price)?)?)
+    })?;
+    Some(())
 }
 
 fn check_decimal(s: &str) -> Option<()> {

--- a/rust-app/src/implementation.rs
+++ b/rust-app/src/implementation.rs
@@ -889,11 +889,11 @@ fn handle_tx_params_2(
     // The JSON struct ends here
     write!(hasher, "}}").ok()?;
 
-    scroller("Paying Gas (1/2)", |w| {
-        Ok(write!(w, "At most {}", from_utf8(gas_limit)?,)?)
+    scroller("Gas Limit (1/2)", |w| {
+        Ok(write!(w, "{} Max", from_utf8(gas_limit)?,)?)
     })?;
-    scroller("Paying Gas (2/2)", |w| {
-        Ok(write!(w, "Price {}", from_utf8(gas_price)?)?)
+    scroller("Gas Price (2/2)", |w| {
+        Ok(write!(w, "KDA {}", from_utf8(gas_price)?)?)
     })?;
     Some(())
 }

--- a/ts-tests/common.ts
+++ b/ts-tests/common.ts
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 export const VERSION = {
   major: 0,
   minor: 2,
-  patch: 4,
+  patch: 5,
 };
 
 const ignoredScreens = [ "Cancel", "Working...", "Quit", "Version"

--- a/ts-tests/signing-tests.ts
+++ b/ts-tests/signing-tests.ts
@@ -1201,7 +1201,8 @@ describe('Create Tx tests', function() {
          { "header": "From", "prompt": "k:9ed54a1020ebbbf8bbe425346498434edd79e4cd36fe874ea58853e78eab4995", "paginate": true },
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "Amount", "prompt": "KDA 1.23" },
-         { "header": "Max Gas", "prompt": "KDA 0.0023" },
+         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
+         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]
@@ -1227,7 +1228,8 @@ describe('Create Tx tests', function() {
          { "header": "From", "prompt": "k:9ed54a1020ebbbf8bbe425346498434edd79e4cd36fe874ea58853e78eab4995", "paginate": true },
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "Amount", "prompt": "KDA 23.67" },
-         { "header": "Max Gas", "prompt": "KDA 0.0023" },
+         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
+         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]
@@ -1255,7 +1257,8 @@ describe('Create Tx tests', function() {
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "To Chain", "prompt": "2" },
          { "header": "Amount", "prompt": "KDA 23.67" },
-         { "header": "Max Gas", "prompt": "KDA 0.0023" },
+         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
+         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]
@@ -1284,7 +1287,8 @@ describe('Create Tx tests', function() {
          { "header": "From", "prompt": "k:9ed54a1020ebbbf8bbe425346498434edd79e4cd36fe874ea58853e78eab4995", "paginate": true },
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "Amount", "prompt": "1.23" },
-         { "header": "Max Gas", "prompt": "KDA 0.0023" },
+         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
+         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]
@@ -1313,7 +1317,8 @@ describe('Create Tx tests', function() {
          { "header": "From", "prompt": "k:9ed54a1020ebbbf8bbe425346498434edd79e4cd36fe874ea58853e78eab4995", "paginate": true },
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "Amount", "prompt": "23.67" },
-         { "header": "Max Gas", "prompt": "KDA 0.0023" },
+         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
+         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]
@@ -1343,7 +1348,8 @@ describe('Create Tx tests', function() {
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "To Chain", "prompt": "2" },
          { "header": "Amount", "prompt": "23.67" },
-         { "header": "Max Gas", "prompt": "KDA 0.0023" },
+         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
+         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]

--- a/ts-tests/signing-tests.ts
+++ b/ts-tests/signing-tests.ts
@@ -1201,8 +1201,8 @@ describe('Create Tx tests', function() {
          { "header": "From", "prompt": "k:9ed54a1020ebbbf8bbe425346498434edd79e4cd36fe874ea58853e78eab4995", "paginate": true },
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "Amount", "prompt": "KDA 1.23" },
-         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
-         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
+         { "header": "Gas Limit (1/2)", "prompt": "2300 Max" },
+         { "header": "Gas Price (2/2)", "prompt": "KDA 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]
@@ -1228,8 +1228,8 @@ describe('Create Tx tests', function() {
          { "header": "From", "prompt": "k:9ed54a1020ebbbf8bbe425346498434edd79e4cd36fe874ea58853e78eab4995", "paginate": true },
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "Amount", "prompt": "KDA 23.67" },
-         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
-         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
+         { "header": "Gas Limit (1/2)", "prompt": "2300 Max" },
+         { "header": "Gas Price (2/2)", "prompt": "KDA 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]
@@ -1257,8 +1257,8 @@ describe('Create Tx tests', function() {
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "To Chain", "prompt": "2" },
          { "header": "Amount", "prompt": "KDA 23.67" },
-         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
-         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
+         { "header": "Gas Limit (1/2)", "prompt": "2300 Max" },
+         { "header": "Gas Price (2/2)", "prompt": "KDA 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]
@@ -1287,8 +1287,8 @@ describe('Create Tx tests', function() {
          { "header": "From", "prompt": "k:9ed54a1020ebbbf8bbe425346498434edd79e4cd36fe874ea58853e78eab4995", "paginate": true },
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "Amount", "prompt": "1.23" },
-         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
-         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
+         { "header": "Gas Limit (1/2)", "prompt": "2300 Max" },
+         { "header": "Gas Price (2/2)", "prompt": "KDA 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]
@@ -1317,8 +1317,8 @@ describe('Create Tx tests', function() {
          { "header": "From", "prompt": "k:9ed54a1020ebbbf8bbe425346498434edd79e4cd36fe874ea58853e78eab4995", "paginate": true },
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "Amount", "prompt": "23.67" },
-         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
-         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
+         { "header": "Gas Limit (1/2)", "prompt": "2300 Max" },
+         { "header": "Gas Price (2/2)", "prompt": "KDA 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]
@@ -1348,8 +1348,8 @@ describe('Create Tx tests', function() {
          { "header": "To", "prompt": "k:83934c0f9b005f378ba3520f9dea952fb0a90e5aa36f1b5ff837d9b30c471790", "paginate": true },
          { "header": "To Chain", "prompt": "2" },
          { "header": "Amount", "prompt": "23.67" },
-         { "header": "Paying Gas (1/2)", "prompt": "At most 2300" },
-         { "header": "Paying Gas (2/2)", "prompt": "Price 1.0e-6" },
+         { "header": "Gas Limit (1/2)", "prompt": "2300 Max" },
+         { "header": "Gas Price (2/2)", "prompt": "KDA 1.0e-6" },
          {"text": "Sign Transaction?", "x": 19, "y": 11,},
          {"text": "Confirm", "x": 43, "y": 11,}
        ]


### PR DESCRIPTION
Restoring gas prompts as 2 fields: Budget and Price

Use of Ledger standard "Max Gas" caused significant size increase, beyond NanoS capacity.